### PR TITLE
remove unnecessary quotes

### DIFF
--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -154,8 +154,8 @@ steps:
             name: Update task definition with additional tags
             command: >
               aws ecs tag-resource \
-                --resource-arn "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
-                --tags "<<parameters.task-definition-tags>>"
+                --resource-arn ${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN} \
+                --tags <<parameters.task-definition-tags>>
   - when:
       condition:
         equal:


### PR DESCRIPTION
remove unnecessary quotes which create confusion around string interpolation.

These quotes make the command difficult to use if you want to quote you values which may have special characters. It also throws an error if more than one key/value is used with the simple format. The json format also requires quotes around key/values. Below are some of the manual tests I did via inlining the orb to show what I mean.

Before change:
Works:
`task-definition-tags:     key=key1,value=value1`
Doesn't Work
`task-definition-tags:     key=key1,value=value1 key=key2,value=value2`

After change:
Works:
`task-definition-tags:     key=key1,value=value1`
`task-definition-tags:     key=tag,value="${CIRCLE_TAG}" key=BuildURL,value="${CIRCLE_BUILD_URL}"`
`task-definition-tags: "'[{\"key\": \"ReleaseIDTest\", \"value\": \"test\"}, {\"key\": \"BuildURLTest\",\"value\": \"test\"}]'"`

Doesn't Work

```
task-definition-tags: "'[{\"key\": \"ReleaseIDTest\", \"value\": \"${CIRCLE_TAG}\"}, {\"key\": \"BuildURLTest\",\"value\": \"${CIRCLE_BUILD_URL}\"}]'"
...
Error: An error occurred (ClientException) when calling the TagResource operation: Some tags contain invalid characters. Valid characters: UTF-8 letters, spaces, numbers and _ . / = + - : @.
```
